### PR TITLE
Check that the actual project directory exists before copying the example from the container

### DIFF
--- a/kubos-sdk.py
+++ b/kubos-sdk.py
@@ -99,11 +99,10 @@ def init_container():
 def _init(name):
     print 'Initializing project: %s ...' % name
     container_source_dir = os.path.join('/', 'examples', 'kubos-rt-example')
-    local_source_dir = os.path.join(os.getcwd(), 'source')
     proj_name_dir = os.path.join(os.getcwd(), name)
 
-    if os.path.isdir(local_source_dir):
-        print >>sys.stderr, 'Source directory already exists. Not overwritting the current directory'
+    if os.path.isdir(proj_name_dir):
+        print >>sys.stderr, 'The project directory %s already exists. Not overwritting the current directory' % proj_name_dir
         sys.exit(1)
 
     shutil.copytree(container_source_dir, proj_name_dir, ignore=shutil.ignore_patterns('.git'))


### PR DESCRIPTION
Currently we are checking if there was a `./source` directory before copying the example from the container to the host at `./<project_name>`

The current check doesn't make sense any more because we now just copy the whole example from the container instead of creating the source directory and creating the module.json like the sdk used to. The new check makes sure that the project directory doesn't exist before trying to copy the example.